### PR TITLE
Add author to manifest

### DIFF
--- a/Alembic.sketchplugin/Contents/Sketch/manifest.json
+++ b/Alembic.sketchplugin/Contents/Sketch/manifest.json
@@ -6,6 +6,7 @@
   "appcast":
     "https://raw.githubusercontent.com/awkward/Alembic/master/.appcast.xml",
   "icon": "icon@2x.png",
+  "author": "Awkward",
   "commands": [
     {
       "script": "alembic.js",


### PR DESCRIPTION
<img width="343" alt="40354717-ccbcb678-5db4-11e8-9c10-f38f1c592cda-1" src="https://user-images.githubusercontent.com/238946/40365863-e953ce0e-5dd5-11e8-8d99-789d33f025d1.png">

It requires an `author` in the manifest. Got this tip from @bomberstudios 👍 